### PR TITLE
Switch MineOS to OpenJDK 17

### DIFF
--- a/mineos.json
+++ b/mineos.json
@@ -18,7 +18,7 @@
     "python38",
     "node",
     "npm",
-    "openjdk16",
+    "openjdk17",
     "wget",
     "bash"
       ],


### PR DESCRIPTION
Mojang has released Minecraft Java Edition 1.18 and it requires Java 17.

It would therefore be preferable if the TrueNAS MineOS plugin used package openjdk17 as described in the mineos.json file as opposed to openjdk16.